### PR TITLE
Implementation of Copy Button and Improvement of <textarea> Display

### DIFF
--- a/content.js
+++ b/content.js
@@ -193,5 +193,9 @@ chrome.runtime.onMessage.addListener(async (request, sender, sendResponse) => {
     const textToCopy = formatLinkAsText(request.format, request.platformOs, request.linkUrl);
     await copyToTheClipboard(textToCopy, request.asHTML);
     sendResponse({ result: textToCopy });
+  } else if (request.message === "copyModifiedText") {
+    const textToCopy = request.modifiedText;
+    await copyToTheClipboard(textToCopy, request.asHTML);
+    sendResponse({ result: textToCopy });
   }
 });

--- a/popup.css
+++ b/popup.css
@@ -5,7 +5,12 @@ body {
 }
 textarea {
   width: 100%;
-  height: 4em;
+  min-height: 4em;
+  max-height: 12em;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-all;
 }
 fieldset {
   border: none;
@@ -15,4 +20,10 @@ fieldset {
 label {
   font: 90% 'Lucida Grande',Geneva,Helvetica,Arial,sans-serif
   margin: 0 4px 0 4px;
+}
+#copyResult {
+  font-size: 90%;
+  color: #1c9503;
+  font-weight: bold;
+  margin-left: 4px;
 }

--- a/popup.html
+++ b/popup.html
@@ -7,8 +7,6 @@
 <script src="popup.js"></script>
 </head>
 <body>
-
-<form>
 <fieldset>
 <label>Copied Text:</label>
 <div>
@@ -17,13 +15,18 @@
 </fieldset>
 
 <fieldset>
+<button id="copyButton">Copy</button>
+<span id="copyResult"></span>
+</fieldset>
+
+<fieldset>
 <label>Switch Format:</label>
 <div id="formatGroup">
 </div>
 </fieldset>
+<hr>
 <fieldset>
 <button id="saveDefaultFormatButton">Set as default</button>
 </fieldset>
-</form>
 </body>
 </html>

--- a/popup.html
+++ b/popup.html
@@ -16,7 +16,7 @@
 
 <fieldset>
 <button id="copyButton">Copy</button>
-<span id="copyResult"></span>
+<span id="copyResult" style="visibility: hidden;">copied!</span>
 </fieldset>
 
 <fieldset>

--- a/popup.js
+++ b/popup.js
@@ -23,6 +23,10 @@ const copyLink = async formatID => {
     format,
     asHTML,
     platformOs: chrome.runtime.PlatformOs,
+  })
+  .catch(error => {
+    console.error('Error copying link:', error);
+    populateText("Failed to get link");
   });
   if (response) {
     populateText(response.result);
@@ -39,6 +43,9 @@ const copyModifiedText = async (modifiedText, formatID) => {
     modifiedText,
     asHTML,
     platformOs: chrome.runtime.PlatformOs,
+  })
+  .catch(error => {
+    console.error('Error copying modified text:', error);
   });
   if (response) {
     populateText(response.result);

--- a/popup.js
+++ b/popup.js
@@ -29,6 +29,24 @@ const copyLink = async formatID => {
   }
 };
 
+const copyModifiedText = async (modifiedText, formatID) => {
+  const options = await getOptions();
+  const asHTML = options['html' + formatID];
+
+  const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
+  const response = await chrome.tabs.sendMessage(tabs[0].id, {
+    message: "copyModifiedText",
+    modifiedText,
+    asHTML,
+    platformOs: chrome.runtime.PlatformOs,
+  });
+  if (response) {
+    populateText(response.result);
+    return true;
+  }
+  return false;
+};
+
 const populateFormatGroup = options => {
   const defaultFormat = options.defaultFormat;
   const cnt = options.count;
@@ -91,4 +109,28 @@ document.addEventListener('DOMContentLoaded', async () => {
       });
     }
   });
+
+  document.getElementById('copyButton').addEventListener('click', async () => {
+    const formatID = getSelectedFormatID();
+    if (formatID) {
+      const result = await copyModifiedText(document.getElementById('textToCopy').value, formatID);
+      if (result) {
+        const resultElem = document.getElementById('copyResult');
+        resultElem.textContent = "copied!";
+        setTimeout(() => {
+          resultElem.textContent = "";
+        }, 3000);
+      }
+    }
+  });
+
+  const textarea = document.getElementById('textToCopy');
+  if (textarea) {
+    const resize = () => {
+      textarea.style.height = 'auto';
+      textarea.style.height = textarea.scrollHeight + 'px';
+    };
+    textarea.addEventListener('input', resize);
+    resize();
+  }
 });

--- a/popup.js
+++ b/popup.js
@@ -123,9 +123,9 @@ document.addEventListener('DOMContentLoaded', async () => {
       const result = await copyModifiedText(document.getElementById('textToCopy').value, formatID);
       if (result) {
         const resultElem = document.getElementById('copyResult');
-        resultElem.textContent = "copied!";
+        resultElem.style.visibility = 'visible';
         setTimeout(() => {
-          resultElem.textContent = "";
+          resultElem.style.visibility = 'hidden';
         }, 3000);
       }
     }


### PR DESCRIPTION
Thanks for the awesome work!

In this pull request, we made the following updates. If everything looks good, go ahead and merge:
- Implemented a copy button.
  - This is handy when you edit after selecting the `HTML` option and then properly re-copy it as `text/html`. It should make integration with rich-text clients like Microsoft Teams a lot smoother.
- Made the text area height adjust dynamically based on the amount of text entered.
- Added error messages to the textarea when the extension can't run on pages like `chrome:` pages.

<img width="281" height="187" alt="image" src="https://github.com/user-attachments/assets/fa1c5727-b5eb-4125-9de3-f4e686fbdf68" />
