### PR TITLE
Fix async handling in chrome.runtime.onMessage listener

### DIFF
--- a/content.js
+++ b/content.js
@@ -188,10 +188,13 @@ const copyToTheClipboard = (textToCopy, asHTML) => {
   });
 };
 
-chrome.runtime.onMessage.addListener(async (request, sender, sendResponse) => {
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   if (request.message === "copyLink") {
-    const textToCopy = formatLinkAsText(request.format, request.platformOs, request.linkUrl);
-    await copyToTheClipboard(textToCopy, request.asHTML);
-    sendResponse({ result: textToCopy });
+    (async () => {
+      const textToCopy = formatLinkAsText(request.format, request.platformOs, request.linkUrl);
+      await copyToTheClipboard(textToCopy, request.asHTML);
+      sendResponse({ result: textToCopy });
+    })();
+    return true;
   }
 });


### PR DESCRIPTION
Thank you for this great extension!

I noticed that version 5.0.2 wasn’t working properly in my environment.

It seems Chrome doesn’t yet support using `async` functions directly as `chrome.runtime.onMessage` listeners—when used this way, `sendMessage` resolves immediately with `undefined`, ignoring the async result.

To work around this, I wrapped the asynchronous logic in an immediately invoked async function (IIFE) and returned `true` from the listener to ensure the response is sent correctly.

